### PR TITLE
feat: add gatsby-browser.js deferred script addition

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,0 +1,14 @@
+const addScript = url => {
+  const script = document.createElement("script")
+  script.src = url
+  script.async = true
+  document.body.appendChild(script)
+}
+
+// most deferred
+exports.onInitialClientRender = () => {
+    window.onload = () => {
+    addScript("https://yourscript/path.com")
+    addScript("https://yourscript2/path.com")
+  }
+}


### PR DESCRIPTION
Hi Verner!

As we discussed I add this PR to add the `gatsby-browser.js` file, which exposes the `onInitialClientRender` API callback (executed after the browser renders the page). This will allow you to defer as much as possible your third-party script addition.

It's a pleasure to work with you as always. Keep me posted about your improvements! 